### PR TITLE
[Release] - update to LinkKit 6.2.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/6.2.0/LinkKit.xcframework.zip",
-  checksum: "991181f01b2966d5d1b248aecc6b82ff502face56bf437e5ee70520eaa8aead6"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/6.2.1/LinkKit.xcframework.zip",
+  checksum: "d979219950d8c203827c7966b1f8ed449cfcec5f1a01ec35669f71d917515318"
 )
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install Plaid Link using [Swift Package Manager](https://github.com/apple/swi
 Alternatively, you can add the following dependency to your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/plaid/plaid-link-ios-spm.git", from: "5.6.0")
+.package(url: "https://github.com/plaid/plaid-link-ios-spm.git", from: "6.0.0")
 ```
 
 ### Why is there a separate repository for Swift Package Manager support?


### PR DESCRIPTION
## LinkKit 6.2.1 - 2025-06-12
### Requirements

| Name | Version |
|------|---------|
| Xcode | >= 16.1.0 |
| iOS | >= 14.0 |

### Changes

- Add Flutter SDK version tracking