### PR TITLE
[Release] LinkKit 6.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/6.2.1/LinkKit.xcframework.zip",
-  checksum: "d979219950d8c203827c7966b1f8ed449cfcec5f1a01ec35669f71d917515318"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/6.3.0/LinkKit.xcframework.zip",
+  checksum: "f3fb97da5394e6013674c3c27e2bee12d3deb8e62419f7a76efd408e577a66c8"
 )
 
 let package = Package(


### PR DESCRIPTION
## LinkKit 6.3.0 – 2025-07-23

### Requirements

| Name  | Version   |
|-------|-----------|
| Xcode | >= 16.1.0 |
| iOS   | >= 14.0   |

### SwiftUI API Enhancements

- Added `makePlaidLinkSheet()` to `Handler`: a convenience method that returns a `View` to present LinkKit using `.fullScreenCover` in SwiftUI applications.
- Added `plaidLink(isPresented:handler:)`: a SwiftUI view modifier to attach LinkKit to any `View`, such as a `Button`, using a pre-configured handler.
- Added `plaidLink(isPresented:token:onSuccess:onExit:onEvent:onLoad:errorView:)`: a flexible SwiftUI modifier for creating LinkKit sessions with just a link token and callbacks—no `Handler` required.

### Testing

- Improved FinanceKit testing capabilities in Sandbox.

### Event Tracking Improvements

- Added event names:
  - `IDENTITY_MATCH_PASSED`
  - `IDENTITY_MATCH_FAILED`
  - `ISSUE_FOLLOWED`
  - `SELECT_ACCOUNT`
- Added `issueID` to `EventMetadata`.

