### PR TITLE
Add PR CI for Swift package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: xcodebuild -version
 
       - name: Resolve package dependencies
-        run: xcodebuild -resolvePackageDependencies -packagePath .
+        run: swift package resolve
 
       - name: Build package
         run: xcodebuild build -scheme LinkKit -destination 'generic/platform=iOS' -derivedDataPath .build/DerivedData

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Swift Package
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve package dependencies
+        run: xcodebuild -resolvePackageDependencies -packagePath .
+
+      - name: Build package
+        run: xcodebuild build -scheme LinkKit -destination 'generic/platform=iOS' -derivedDataPath .build/DerivedData

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/6.4.3/LinkKit.xcframework.zip",
-  checksum: "7b3a6120d0f342ea53433fecdd0f89e307e9428eda9563b42fe37b6e65e76ef9"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta1/LinkKit.xcframework.zip",
+  checksum: "4730fbaa8eb446f845e6c4570ba47212469f4e9cd913b87d591a83d3e5576f4e"
 )
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta1/LinkKit.xcframework.zip",
-  checksum: "4730fbaa8eb446f845e6c4570ba47212469f4e9cd913b87d591a83d3e5576f4e"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta2/LinkKit.xcframework.zip",
+  checksum: "5a7d0a8dd6e84f4775b1eccccfa158f928eeef68b28505172d64836e5c47cf4e"
 )
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,13 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta2/LinkKit.xcframework.zip",
-  checksum: "5a7d0a8dd6e84f4775b1eccccfa158f928eeef68b28505172d64836e5c47cf4e"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta3/LinkKit.xcframework.zip",
+  checksum: "5ea3d8a021e371f7cec3cbc30cef7f55516bd5e9a85c42f08a2424b4581add51"
 )
 
 let package = Package(
   name: "LinkKit",
-  platforms: [.iOS(.v14)],
+  platforms: [.iOS(.v15)],
   products: [.library(name: "LinkKit", targets: ["LinkKit", "LinkKitSub"])],
   targets: [
     linkKitXCFramework,

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let linkKitXCFramework = Target.binaryTarget(
 
 let package = Package(
   name: "LinkKit",
-  platforms: [.iOS(.v15)],
+  platforms: [.iOS(.v14)],
   products: [.library(name: "LinkKit", targets: ["LinkKit", "LinkKitSub"])],
   targets: [
     linkKitXCFramework,

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 /// This XCFramework can be used by Xcode 16.1.0 and later.
 let linkKitXCFramework = Target.binaryTarget(
   name: "LinkKit",
-  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta3/LinkKit.xcframework.zip",
-  checksum: "5ea3d8a021e371f7cec3cbc30cef7f55516bd5e9a85c42f08a2424b4581add51"
+  url: "https://github.com/plaid/plaid-link-ios/releases/download/7.0.0-beta4/LinkKit.xcframework.zip",
+  checksum: "0b8e40b36c71f6cf1d9d4d2452a4296d08bb43001dd8f528e1c3646c73aba1e5"
 )
 
 let package = Package(


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for PR validation
- resolve Swift package dependencies to validate the binary target URL and checksum
- build the LinkKit package for a generic iOS destination on macos-15

## Testing
- not run locally: xcodebuild requires full Xcode, but this machine only has Command Line Tools selected